### PR TITLE
fix: 🐛 update wordpress-theme-centos to v1.0.20

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,4 +92,4 @@ httpd_navbar:
 # - https://gitlab.com/CentOS/artwork/centos-web/wordpress-theme-centos/-/releases
 # ===============================================================================
 wp_theme_name: wordpress-theme-centos
-wp_theme_version: "1.0.16"
+wp_theme_version: "1.0.20"


### PR DESCRIPTION
This update sets the custom sidebar name explicitly and correct page title and content margins.